### PR TITLE
Various QOL improvements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,8 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      - uses: actions-rs/cargo@v1
+      - name: cargo fmt
+        uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check
@@ -28,7 +29,8 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      - uses: actions-rs/cargo@v1
+      - name: cargo clippy
+        uses: actions-rs/cargo@v1
         with:
           command: clippy
 
@@ -39,7 +41,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      - name: test
+      - name: cargo test
         uses: actions-rs/cargo@v1
         with:
           command: test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  rustfmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - name: test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test

--- a/README.markdown
+++ b/README.markdown
@@ -29,6 +29,10 @@ stories activity
 stories --help
 ```
 
+## Notes
+
+- this assumes you use tracker's [github integration](https://www.pivotaltracker.com/help/articles/github_integration/) and deliver stories [via commit messages](https://www.pivotaltracker.com/help/articles/github_integration/#using-the-github-integration-commits)
+
 ## Installation
 
 Homebrew (mac):
@@ -56,7 +60,7 @@ throw `alias s=stories` in your ~/.zshrc ~/.bashrc for good measure.
    mkdir -p ~/.config/stories
    echo $YOUR_TRACKER_API_TOKEN > ~/.config/stories/tracker_api_token.txt
    ```
-3. drop a `stories.json` file in your project directory with a tracker project id, e.g. 
+3. drop a `stories.json` file in your project directory with a tracker project id, e.g.
    ```json
-   {"project_id":1234}
+   { "project_id": 1234 }
    ```

--- a/src/api/schema.rs
+++ b/src/api/schema.rs
@@ -85,3 +85,12 @@ pub struct EntityReference {
     pub id: u64,
     pub name: String,
 }
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Me {
+    pub id: u64,
+    pub name: String,
+    pub initials: String,
+    pub username: String,
+    pub email: String,
+}

--- a/src/api/schema.rs
+++ b/src/api/schema.rs
@@ -94,3 +94,29 @@ pub struct Me {
     pub username: String,
     pub email: String,
 }
+
+/// example error:
+///
+/// {
+///   "code": "unfound_resource",
+///   "kind": "error",
+///   "error": "The object you tried to access could not be found.  It may have been removed by another user, you may be using the ID of another object type, or you may be trying to access a sub-resource at the wrong point in a tree."
+/// }
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ApiError {
+    #[serde(rename = "code")]
+    pub code: String,
+
+    #[serde(rename = "kind")]
+    pub kind: String,
+
+    #[serde(rename = "error")]
+    pub error: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum MaybeStoryDetail {
+    StoryDetail(StoryDetail),
+    ApiError(ApiError)
+}

--- a/src/api/schema.rs
+++ b/src/api/schema.rs
@@ -118,5 +118,5 @@ pub struct ApiError {
 #[serde(untagged)]
 pub enum MaybeStoryDetail {
     StoryDetail(StoryDetail),
-    ApiError(ApiError)
+    ApiError(ApiError),
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,9 @@
+// dear reader:
+//
+// the following is my 2nd rust program, and it panics less than my first one,
+// but is still very amateur level stuff and thrown together without much
+// consideration for aesthetics.
+
 use api::schema::{StoryState, StoryType};
 use chrono::{DateTime, Local};
 use clap::{Args, Parser, Subcommand};

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,7 +116,9 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match &cli.command {
-        Some(Commands::View(view_args)) => print_result(view(view_args).await),
+        Some(Commands::View(view_args)) => {
+            print_result(view(view_args).await);
+        }
         Some(Commands::Mine(mine_args)) => {
             print_result(mine(mine_args).await);
         }
@@ -129,7 +131,6 @@ async fn main() -> Result<()> {
         Some(Commands::Pr(pr_args)) => {
             print_result(pull_request(pr_args).await);
         }
-
         Some(Commands::Activity {}) => {
             print_result(activity().await);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use mdcat::push_tty;
 use mdcat::terminal::TerminalProgram;
 use regex::Regex;
 use reqwest::header::USER_AGENT;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize};
 use serde_json::{Map, Number, Value};
 use slugify::slugify;
 
@@ -208,15 +208,6 @@ pub async fn pull_request(pr_args: &PrArgs) -> anyhow::Result<String> {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
-pub struct Me {
-    id: u64,
-    name: String,
-    initials: String,
-    username: String,
-    email: String,
-}
-
 pub async fn whoami() -> anyhow::Result<String> {
     let data = tracker_me().await?;
     Ok(format!("you: {}", data.email))
@@ -324,7 +315,7 @@ pub async fn branch(
     Ok(format!("{}\nupdated story {}", git_message, data.id))
 }
 
-async fn tracker_me() -> anyhow::Result<Me> {
+async fn tracker_me() -> anyhow::Result<api::schema::Me> {
     let token = read_api_token()?;
     let client = tracker_api_client().await?;
 
@@ -336,7 +327,7 @@ async fn tracker_me() -> anyhow::Result<Me> {
     match &cached {
         Ok(cached) => Ok(serde_json::from_slice(cached)?),
         Err(_) => {
-            let data: Me = client
+            let data: api::schema::Me = client
                 .get("https://www.pivotaltracker.com/services/v5/me")
                 .send()
                 .await?

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,6 +82,7 @@ enum Commands {
     },
 
     /// Checks out a git branch and changes the story's state to started
+    #[clap(alias = "br")]
     Branch {
         story_id: u64,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -420,6 +420,10 @@ pub struct ViewArgs {
     /// Open the story in a web browser
     #[arg(short, long)]
     web: bool,
+
+    /// Print json response
+    #[arg(short, long)]
+    json: bool,
 }
 
 pub async fn view(view_args: &ViewArgs) -> anyhow::Result<()> {
@@ -444,9 +448,14 @@ pub async fn view(view_args: &ViewArgs) -> anyhow::Result<()> {
         project_id, branch_id
     );
 
-    // let response_text = client.get(&url).send().await?.text().await?;
-    // println!("{}", response_text);
-    let data: api::schema::MaybeStoryDetail = client.get(url).send().await?.json().await?;
+    let response = client.get(url).send().await?;
+
+    if view_args.json {
+        println!("{}", response.text().await?);
+        return Ok(());
+    }
+
+    let data: api::schema::MaybeStoryDetail = response.json().await?;
 
     match data {
         api::schema::MaybeStoryDetail::StoryDetail(sd) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,14 +58,6 @@ struct StoryRow {
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 struct Cli {
-    // /// Sets a custom config file
-    // #[arg(short, long, value_name = "FILE")]
-
-    // config: Option<PathBuf>,
-    /// Turn debugging information on
-    #[arg(short, long, action = clap::ArgAction::Count)]
-    debug: u8,
-
     #[command(subcommand)]
     command: Option<Commands>,
 }
@@ -637,11 +629,13 @@ pub fn read_branch_id() -> anyhow::Result<String> {
                         {}
 
                     what we're looking for:
-                        12345-some-feature
+                        some-feature-12345
 
-                run the following to checkout a relevant branch for a story
+                run the following to create a relevant branch for a story, and set the story's
+                status to "started"
 
-                    $ stories start 12345
+                    $ stories branch 12345
+
             "#},
             branch
         ))

--- a/src/main.rs
+++ b/src/main.rs
@@ -220,6 +220,7 @@ pub struct BranchArgs {
     #[arg(short, long)]
     estimate: Option<u8>,
 }
+
 pub async fn branch(branch_args: &BranchArgs) -> anyhow::Result<()> {
     let client = tracker_api_client().await?;
     let project_id = read_project_id()?;
@@ -328,15 +329,15 @@ async fn tracker_me() -> anyhow::Result<api::schema::Me> {
     }
 }
 
-#[derive(Tabled, Debug)]
-struct ActivityRow {
-    #[tabled(rename = "Story")]
-    name: String,
-    #[tabled(rename = "Changes")]
-    highlights: String,
-}
-
 async fn activity() -> anyhow::Result<()> {
+    #[derive(Tabled, Debug)]
+    struct ActivityRow {
+        #[tabled(rename = "Story")]
+        name: String,
+        #[tabled(rename = "Changes")]
+        highlights: String,
+    }
+
     let client = tracker_api_client().await?;
     let project_id = read_project_id()?;
 
@@ -460,19 +461,6 @@ pub async fn view(view_args: &ViewArgs) -> anyhow::Result<()> {
     }
 
     Ok(())
-}
-
-fn format_current_state(state: &StoryState) -> ColoredString {
-    match state {
-        StoryState::Planned => "---".black(),
-        StoryState::Unscheduled => "---".black(),
-        StoryState::Unstarted => "···".black(),
-        StoryState::Started => "☐☐☐".blue(),
-        StoryState::Finished => "☑☐☐".cyan(),
-        StoryState::Delivered => "☑☑☐".green(),
-        StoryState::Accepted => "☑☑☑".green(),
-        StoryState::Rejected => "☑☑☒".red(),
-    }
 }
 
 #[derive(Args)]
@@ -723,4 +711,17 @@ fn print_markdown(text: &str) -> anyhow::Result<()> {
             Err(anyhow!("Cannot render markdown to stdout: {:?}", error))
         }
     })
+}
+
+fn format_current_state(state: &StoryState) -> ColoredString {
+    match state {
+        StoryState::Planned => "---".black(),
+        StoryState::Unscheduled => "---".black(),
+        StoryState::Unstarted => "···".black(),
+        StoryState::Started => "☐☐☐".blue(),
+        StoryState::Finished => "☑☐☐".cyan(),
+        StoryState::Delivered => "☑☑☐".green(),
+        StoryState::Accepted => "☑☑☑".green(),
+        StoryState::Rejected => "☑☑☒".red(),
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use mdcat::push_tty;
 use mdcat::terminal::TerminalProgram;
 use regex::Regex;
 use reqwest::header::USER_AGENT;
-use serde::{Deserialize};
+use serde::Deserialize;
 use serde_json::{Map, Number, Value};
 use slugify::slugify;
 
@@ -108,12 +108,8 @@ enum Commands {
 
     /// Recent things you have done on tracker
     Activity {},
-    // ideas:
-    // standup
-    // - lists stories recently completed
-    // - recent commits to main branch
-
-    // cache clear
+    // future commands:
+    // - cache clear (handle changes to tracker Me record)
 }
 
 #[derive(Args)]
@@ -534,11 +530,18 @@ pub async fn mine(json: bool) -> anyhow::Result<String> {
         })
         .collect();
 
-    let (terminal_size::Width(term_width), terminal_size::Height(_height)) =
-        terminal_size::terminal_size().unwrap();
-    let width = term_width as usize; // todo why casting?
-    let name_wrap = match width > 80 {
-        true => 44 + (width - 80),
+    let size = terminal_size::terminal_size();
+
+    let term_width: usize = match size {
+        Some(size_v) => {
+            let (terminal_size::Width(w), _) = size_v;
+            w.into()
+        }
+        None => 120,
+    };
+
+    let name_wrap: usize = match term_width > 80 {
+        true => 44 + (term_width - 80),
         false => 44,
     };
 


### PR DESCRIPTION
- Add stories pr command
- Improve handling of git command failures (untested)
- add a note
- Update error message, remove unused clap args
- Add note about github integration
- Move Me type into schema
- Fix bug where piping `mine` would panic
- Add br alias for branch
- better id finding, differnet error handling for story view errors
- Refactor command function output type from string to none
- Refactor view args type
- Refactor branch args type
- Refactor mine args
- move type defs near commands, refactor activity output
- Nest structs
- Cleanup
